### PR TITLE
Bumps @vtexlab/gatsby-theme-instore-core to 0.4.4-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@vtex/gatsby-instore-plugin-example-2": "^0.0.11",
     "@vtex/gatsby-instore-plugin-example-3": "^0.0.11",
     "@vtex/instore-admin-example": "^0.0.17",
-    "@vtexlab/gatsby-theme-instore-core": "0.4.3",
+    "@vtexlab/gatsby-theme-instore-core": "0.4.4-beta.0",
     "@vtexlab/gatsby-theme-instore-poc": "^0.0.36",
     "gatsby": "3.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4221,10 +4221,10 @@
     vtex-tachyons "^3.2.2"
     whatwg-fetch "2.0.4"
 
-"@vtexlab/gatsby-theme-instore-core@0.4.3":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.4.3.tgz#f8ab06d80bd690e17408952e5b468461f8774f81"
-  integrity sha512-P8spYM9Sx1SCiDn7RptG5MdhnY5GS6LiI+gfDVEmKL1aN2SMM0fFi7dIHj2R6w3lV92eQorQRulHsdYcTMFU9A==
+"@vtexlab/gatsby-theme-instore-core@0.4.4-beta.0":
+  version "0.4.4-beta.0"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.4.4-beta.0.tgz#975f498c5eb63eaf36ab1127773e7a2a4b7d4f38"
+  integrity sha512-MFwNOcXf31VEy64DUG+jN5GBJ4bEZayRqjENiyWdt24KkBGtRIsMMcihg+XjBE74gZFxbjrrRkXeOmuGOo7BXA==
   dependencies:
     "@babel/core" "^7.12.13"
     "@babel/plugin-transform-typescript" "^7.13.0"
@@ -4275,6 +4275,7 @@
     react-intl "^5.15.8"
     react-intl-legacy "npm:react-intl@2.9.0"
     react-no-ssr "^1.1.0"
+    react-portal "^4.2.1"
     react-redux "^7.2.2"
     react-relay "^11.0.0"
     react-relay-network-modern "^6.0.0"
@@ -15535,6 +15536,13 @@ react-popper@^1.0.2, react-popper@^1.3.2, react-popper@^1.3.4:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-portal@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-4.2.1.tgz#12c1599238c06fb08a9800f3070bea2a3f78b1a6"
+  integrity sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-reconciler@^0.23.0:
   version "0.23.0"


### PR DESCRIPTION
Updates @vtexlab/gatsby-theme-instore-core