### PR TITLE
Bumps @vtexlab/gatsby-theme-instore-core to 0.16.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.16.0-beta.2",
+    "@vtexlab/gatsby-theme-instore-core": "0.16.0-beta.3",
     "gatsby": "^3.7.2"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.15.0",
+    "@vtexlab/gatsby-theme-instore-core": "0.16.0-beta.2",
     "gatsby": "^3.7.2"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.16.0-beta.3",
+    "@vtexlab/gatsby-theme-instore-core": "0.16.0-beta.4",
     "gatsby": "^3.7.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,10 +3449,10 @@
     vtex-tachyons "^3.2.2"
     whatwg-fetch "2.0.4"
 
-"@vtexlab/gatsby-theme-instore-core@0.16.0-beta.3":
-  version "0.16.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.16.0-beta.3.tgz#306ee10efcacca9e2b880a74a9357f65099b5e0a"
-  integrity sha512-lFw017wIJGlUrc7a6pp/CwH33RQqzVdWAsHwxRaIpfYdodfYPD3X5JBIgFsHDLd4Qn+mxNKHLvY9msjGwpqxrQ==
+"@vtexlab/gatsby-theme-instore-core@0.16.0-beta.4":
+  version "0.16.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.16.0-beta.4.tgz#8703fa41ea493437bf0013c301614218e087e00f"
+  integrity sha512-Sdi/oEhd4wJFKCjY8aG6Ql2aJA4fsZv2FTbxviInrGyAobjpdI0RNzDsdSts+1SQcHPEPiuxIuzAecHecj4ddA==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,10 +3449,10 @@
     vtex-tachyons "^3.2.2"
     whatwg-fetch "2.0.4"
 
-"@vtexlab/gatsby-theme-instore-core@0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.15.0.tgz#c39f4ae437a76b661249748b93e438eca56410d9"
-  integrity sha512-bv/4BgkJ/EC15fVHr31A/EJIIwFCca+Ka66O9OBsEEek53NLto29kSbvK0/TFxc3SHRgjbhwBoAolzvXu3wDow==
+"@vtexlab/gatsby-theme-instore-core@0.16.0-beta.2":
+  version "0.16.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.16.0-beta.2.tgz#11c26878ff86a7f26cbdf50123996afe65e413c0"
+  integrity sha512-pWXue4PlfsKYe7O5Cm8DXboBvXlv2D86rxiv+IKpYqLCn/iO7fUGvGbgJGz7QsqbqGWTAvwHqEwqI9tUjidm1w==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,10 +3449,10 @@
     vtex-tachyons "^3.2.2"
     whatwg-fetch "2.0.4"
 
-"@vtexlab/gatsby-theme-instore-core@0.16.0-beta.2":
-  version "0.16.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.16.0-beta.2.tgz#11c26878ff86a7f26cbdf50123996afe65e413c0"
-  integrity sha512-pWXue4PlfsKYe7O5Cm8DXboBvXlv2D86rxiv+IKpYqLCn/iO7fUGvGbgJGz7QsqbqGWTAvwHqEwqI9tUjidm1w==
+"@vtexlab/gatsby-theme-instore-core@0.16.0-beta.3":
+  version "0.16.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.16.0-beta.3.tgz#306ee10efcacca9e2b880a74a9357f65099b5e0a"
+  integrity sha512-lFw017wIJGlUrc7a6pp/CwH33RQqzVdWAsHwxRaIpfYdodfYPD3X5JBIgFsHDLd4Qn+mxNKHLvY9msjGwpqxrQ==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"


### PR DESCRIPTION
Updates @vtexlab/gatsby-theme-instore-core