### PR TITLE
Bumps @vtexlab/gatsby-theme-instore-core to 0.21.1-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.21.0",
+    "@vtexlab/gatsby-theme-instore-core": "0.21.1-beta.0",
     "gatsby": "^3.7.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3653,10 +3653,10 @@
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.21.0.tgz#d01a4fa6f0425eae91277564928e031847eabd2c"
-  integrity sha512-O75fGVCd8c1eGCZ6dDpA24WZmLVySLwnrAyObbBNfewiR3C9iJQhLp1vMRAKdhX23iJmhavaNDhvKIEPhN8JpA==
+"@vtexlab/gatsby-theme-instore-core@0.21.1-beta.0":
+  version "0.21.1-beta.0"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.21.1-beta.0.tgz#b767e26c6d583a18d8039b907aa5d156e7c20780"
+  integrity sha512-n/EHEpjBj3YU8AvW/sXNPemdX1NDYaQVQVQ2DrojLO1Q0BzKRTKabw996nMFNO7Zpf2zSdkoDx7FNXOOZteF1A==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"


### PR DESCRIPTION
Updates @vtexlab/gatsby-theme-instore-core