### PR TITLE
Bumps @vtexlab/gatsby-theme-instore-core to 0.26.1-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.24.0",
+    "@vtexlab/gatsby-theme-instore-core": "0.24.1",
     "gatsby": "^3.7.2"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.24.1",
+    "@vtexlab/gatsby-theme-instore-core": "0.26.1-beta.0",
     "gatsby": "^3.7.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3653,10 +3653,10 @@
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.24.0.tgz#8c431d673d798a48d6adea9fa9237c099d7f2bea"
-  integrity sha512-1CEFKWgiEpo6WruPfPJiqsA26Jh3AJlPRYPj95ULLJlAi6jzu1wQWJ5WY1EwTd7DxWgSeQD5uONJgPrm4FfVPg==
+"@vtexlab/gatsby-theme-instore-core@0.24.1":
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.24.1.tgz#46d072cd27d970aac634ce719271d760ffba6d70"
+  integrity sha512-1mixb6haRV/P9UDYkBp5+ga/g21YgsH4iovPni5QRpp/7l/DEXqjDVmJBS3ffhwyURxPvYzMufjAfUO7B03fIw==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3550,10 +3550,10 @@
   resolved "https://registry.yarnpkg.com/@vtex/tsconfig/-/tsconfig-0.5.6.tgz#c0eb4222a75d1b8a4fefb1d85bbd9349880ddbe5"
   integrity sha512-3pdtp0QiUjW3YqyA+2YPV3AsAJ68wHWELrg7JMlr7ULHNb4mUfmTBx31zbWG94K3OWp0KJFfF3ytQ+I68foqKA==
 
-"@vtexlab/checkout-instore@2.198.1":
-  version "2.198.1"
-  resolved "https://registry.yarnpkg.com/@vtexlab/checkout-instore/-/checkout-instore-2.198.1.tgz#99fd12a9a73ad198615e3c371c8719cf4f42724e"
-  integrity sha512-1y/mTosMAeIte8wCiwjRFD3duBEbORNeZcSrrqg4m4x99YH6/bNtqQxnoJJturFqzmQLLRARZymD529npyjrmQ==
+"@vtexlab/checkout-instore@2.201.2":
+  version "2.201.2"
+  resolved "https://registry.yarnpkg.com/@vtexlab/checkout-instore/-/checkout-instore-2.201.2.tgz#df1492aae5ef78f1bd2ea9113eec65f734e89af7"
+  integrity sha512-deI4lCkCZ4yQqoJnRq3kQQMnq4zmT/cf3xklfGn8f8Fk+FQEuMmzqLDSDlyvitu127HknczU+Lcu8DxMUp7wPg==
   dependencies:
     "@fullstory/browser" "^1.4.5"
     "@material-ui/core" "^3.1.2"
@@ -3567,6 +3567,7 @@
     "@vtex/axios-concurrent-retry" "^4.0.10"
     "@vtex/butik" "^1.3.6"
     "@vtex/delivery-packages" "2.18.0"
+    "@vtex/diagnostics-web" "^0.3.1"
     "@vtex/estimate-calculator" "^1.1.0"
     "@vtex/evidence-client-js" "^2.1.1"
     "@vtex/phone" "^4.8.3"
@@ -3575,11 +3576,13 @@
     "@vtex/styleguide" "^9.145.0"
     "@vtexlab/instore-profile" "2.9.6"
     "@vtexlab/product-ops-utils" "^0.1.0"
+    abortcontroller-polyfill "^1.7.5"
     asap "^2.0.5"
     axios "^0.18.0"
     base64-url "^2.2.0"
     classnames "^2.2.5"
     clean-css "^4.2.3"
+    cockatiel "2.0.2"
     connected-react-router "^6.9.1"
     dexie "^3.0.3"
     events "^1.1.1"
@@ -3645,18 +3648,18 @@
     whatwg-fetch "2.0.4"
     yup "^0.32.11"
 
-"@vtexlab/gatsby-plugin-instore-nginx@0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.24.0.tgz#58cd4526f343dea553795d5f7a5814bc30c35b8a"
-  integrity sha512-yTb9TTMVsrVsAdjIk2OLcrzH7K8CvqV2ES19G0H3EbQ8D98jC20bH/wGKRjIzhMmP0CQMBL24146wUtMUdOCkQ==
+"@vtexlab/gatsby-plugin-instore-nginx@0.25.0":
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-plugin-instore-nginx/-/gatsby-plugin-instore-nginx-0.25.0.tgz#f606556882cbc1ea901d32448c6c1eb673e6207e"
+  integrity sha512-PzumqKMPWMern9MW825vUKaQnCmeWa2BVT8u4TLPcmVhKNimz4rCQQo7IEwyWCftwkxlsOay3rGtxIJMdG+cLA==
   dependencies:
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.24.1":
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.24.1.tgz#46d072cd27d970aac634ce719271d760ffba6d70"
-  integrity sha512-1mixb6haRV/P9UDYkBp5+ga/g21YgsH4iovPni5QRpp/7l/DEXqjDVmJBS3ffhwyURxPvYzMufjAfUO7B03fIw==
+"@vtexlab/gatsby-theme-instore-core@0.26.1-beta.0":
+  version "0.26.1-beta.0"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.26.1-beta.0.tgz#c7edabbe9a197d520f3415705de02730bb3a04e4"
+  integrity sha512-MXWTBhCdRstFVvnoT/CuIk6LsnU2yzHoJStjyEiw2u2Nik2O4YrSXVySn2Wi0y6avLk/p7bCfG4dDvP/wlwCNQ==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"
@@ -3671,8 +3674,8 @@
     "@vtex/gatsby-plugin-admin-ui" "^0.6.6"
     "@vtex/gatsby-plugin-graphql" "^0.277.2"
     "@vtex/phone" "^4.10.5"
-    "@vtexlab/checkout-instore" "2.198.1"
-    "@vtexlab/gatsby-plugin-instore-nginx" "0.24.0"
+    "@vtexlab/checkout-instore" "2.201.2"
+    "@vtexlab/gatsby-plugin-instore-nginx" "0.25.0"
     abortcontroller-polyfill "^1.7.3"
     assert "^2.0.0"
     babel-plugin-relay "^10.1.3"
@@ -3952,7 +3955,7 @@ abort-controller@3.0.0, abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-abortcontroller-polyfill@^1.7.3:
+abortcontroller-polyfill@^1.7.3, abortcontroller-polyfill@^1.7.5:
   version "1.7.5"
   resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.5.tgz#6738495f4e901fbb57b6c0611d0c75f76c485bed"
   integrity sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==
@@ -5696,6 +5699,11 @@ coa@^2.0.2:
     "@types/q" "^1.5.1"
     chalk "^2.4.1"
     q "^1.1.2"
+
+cockatiel@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/cockatiel/-/cockatiel-2.0.2.tgz#b8bc06df324dd1c769833c4d91478eb1d5519b4f"
+  integrity sha512-ehw7t3twohGiMTxARX0AcFiUxndXLhnIBWbnRnHtfde2jRywlPpPB/o3s9YSptXPj6tkOG0fzET4CUUx4GIpEg==
 
 cockatiel@3.0.0-anyengine.0:
   version "3.0.0-anyengine.0"


### PR DESCRIPTION
Updates @vtexlab/gatsby-theme-instore-core