### PR TITLE
Merge pull request #165 from vtex-sites/renovate/vtexlab-gatsby-theme…

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.29.4",
+    "@vtexlab/gatsby-theme-instore-core": "0.29.6-beta.0",
     "gatsby": "^3.7.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,10 +3656,10 @@
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.29.4":
-  version "0.29.4"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.4.tgz#6a80b42c03cbec98a60ac916180d832aeb635673"
-  integrity sha512-7VH8ewhHIR662Not/Z9Oww0cgRk3BV45Sc3WW/rLaWGcOgeih0LiPMRVlg6sQUxqzstdAyT8Qs/YBPqLr7RlBQ==
+"@vtexlab/gatsby-theme-instore-core@0.29.6-beta.0":
+  version "0.29.6-beta.0"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.6-beta.0.tgz#ef2280c90c8dbc5b44b04cbf94b787712f008d69"
+  integrity sha512-XPzcCuvwdwTZZwpjaj3x62O3G4vOrt3KAlrcI7jFWaUmtF3HzK8/0MdnOPMNxGfnX5rTPVDndRfUOPgzLMxTzQ==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"


### PR DESCRIPTION
…-instore-core-0.x

fix(deps): update dependency @vtexlab/gatsby-theme-instore-core to v0.29.5