### PR TITLE
Bumps @vtexlab/gatsby-theme-instore-core to 0.29.10-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.29.9",
+    "@vtexlab/gatsby-theme-instore-core": "0.29.10-beta.0",
     "gatsby": "^3.7.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,10 +3656,10 @@
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.29.9":
-  version "0.29.9"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.9.tgz#03e9b7e871a510aa07eab71514fde090d440146d"
-  integrity sha512-MTtECfVmnM0MhRdgCWzuK2cKJJ8iuQvX25QyRbCliTiddAYhYGGkOwxXc1I44Amk4ILUz3KRlXMa363vncN7+g==
+"@vtexlab/gatsby-theme-instore-core@0.29.10-beta.0":
+  version "0.29.10-beta.0"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.10-beta.0.tgz#ebd3044d79d95d503f0e3158a1fd24d31085e419"
+  integrity sha512-oM7juI/fT9RUSaE1A1Km+lEAUkh/K35aMujbDUPLxTIBEWXns3IO81Yy3rAv/MnuPbH6nWqFpIbJo8X+DlIGLQ==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"


### PR DESCRIPTION
Updates @vtexlab/gatsby-theme-instore-core