### PR TITLE
Bumps @vtexlab/gatsby-theme-instore-core to 0.29.16-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cypress:open": "cypress open"
   },
   "dependencies": {
-    "@vtexlab/gatsby-theme-instore-core": "0.29.15",
+    "@vtexlab/gatsby-theme-instore-core": "0.29.16-beta.0",
     "gatsby": "^3.7.2"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,10 +3656,10 @@
     kebab-hash "^0.1.2"
     webpack-assets-manifest "^4.0.6"
 
-"@vtexlab/gatsby-theme-instore-core@0.29.15":
-  version "0.29.15"
-  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.15.tgz#7d3550b128a2c1d3c7a4a3764be14f742be4934c"
-  integrity sha512-5wgLxff5cVFmKURaqr0Bkv4Idi77RzEKgMmagiEzUDDorY+bcRlSuH371QayGqpcZ2LyL8j8kiaErA3h0o/YBA==
+"@vtexlab/gatsby-theme-instore-core@0.29.16-beta.0":
+  version "0.29.16-beta.0"
+  resolved "https://registry.yarnpkg.com/@vtexlab/gatsby-theme-instore-core/-/gatsby-theme-instore-core-0.29.16-beta.0.tgz#e598a8a522bee8648f53f2991a5a2931674b51cf"
+  integrity sha512-Cn4SGyXd8L8fQCyy32aZ8EGoFV1Yaa6KvI8Pwq/7/H7B7VSLzySOB4r+uvvaGy+iuHNhTq1XFIlRnHQEeuWfLw==
   dependencies:
     "@babel/core" "^7.17.8"
     "@babel/plugin-transform-typescript" "^7.13.0"


### PR DESCRIPTION
Updates @vtexlab/gatsby-theme-instore-core